### PR TITLE
SITES-16455: add link editing field to title

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -63,6 +63,13 @@
                     "value": "h6"
                   }
                 ]
+              },
+              {
+                "component": "text-input",
+                "valueType": "string",
+                "name": "href",
+                "value": "",
+                "label": "Link"
               }
             ]
           }

--- a/component-models.json
+++ b/component-models.json
@@ -34,6 +34,13 @@
             "value": "h6"
           }
         ]
+      },
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "href",
+        "value": "",
+        "label": "Link"
       }
     ]
   },


### PR DESCRIPTION
Adds an edit field for headings to add a link and store it in a property named` href`.

Fix SITES-16455

